### PR TITLE
Return to using flat variables for hornet config

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,11 @@ It is possible to edit `/var/lib/hornet/config.json` manually and restart HORNET
 
 The recommended way to configure the file without having to worry about it getting overwritten is by copying the variables file to a new overwrite file.
 
-**NOTE** due to recent changes the method below may differ. (WIP)
-
 Copy the config variables file to a new file:
 ```sh
 cp /opt/hornet-playbook/group_vars/all/hornet-config-file.yml /opt/hornet-playbook/group_vars/all/z-append.yml
 ```
-Edit the `/opt/hornet-playbook/group_vars/all/z-append.yml` as required (using nano, vi or your preferred editor). The variable names are similar to how you'd read the `config.json`. For example `hornet_coo_merkle_tree_depth` would correspond to `coordinator.merkleTreeFilePath` in `config.json`. If you want to see the actual mapping you can view the template file in `/opt/hornet-playbook/roles/hornet/templates/config.json.j2`.
+Edit the `/opt/hornet-playbook/group_vars/all/z-append.yml` as required (using nano, vi or your preferred editor). The variable names are similar to how you'd read the `config.json`. For example `hornet_config_snapshots_local_downloadURLs` corresponds to `snapshots.local.downloadURLs` in `config.json`. If you want to see the actual mapping you can view the template file in `/opt/hornet-playbook/roles/hornet/templates/config.json.j2`.
 
 Then re-run the playbook while tagging the task to update the configuration file. Any variables you have overwritten and modified in `z-append.yml` will be applied and take precedence.
 ```sh

--- a/group_vars/all/hornet-config-file.yml
+++ b/group_vars/all/hornet-config-file.yml
@@ -4,121 +4,141 @@
 
 #
 # config.json
-hornet_configuration:
-  useProfile: auto
-  httpAPI:
-    excludeHealthCheckFromAuth: false
-    basicAuth:
-      enabled: false
-      username: ''
-      passwordHash: ''
-      passwordSalt: ''
-    permitRemoteAccess:
-    - getNodeInfo
-    - getBalances
-    - checkConsistency
-    - getTipInfo
-    - getTransactionsToApprove
-    - getInclusionStates
-    - getNodeAPIConfiguration
-    - wereAddressesSpentFrom
-    - broadcastTransactions
-    - findTransactions
-    - storeTransactions
-    - getTrytes
-    - attachToTangle
-    - interruptAttachingToTangle
-    whitelistedAddresses: []
-    bindAddress: "127.0.0.1:{{ hornet_ports.api.port }}"
-    limits:
-      bodyLengthBytes: 1000000
-      findTransactions: 1000
-      getTrytes: 1000
-      requestsList: 1000
-  dashboard:
-    bindAddress: "{{ hornet_graph_internal_address }}:{{ hornet_dashboard_internal_port }}"
-    theme: default
-    basicAuth:
-      enabled: false
-      username: ''
-      passwordHash: ''
-      passwordSalt: ''
-  snapshots:
-    loadType: local
-    local:
-      intervalSynced: 50
-      intervalUnsynced: 1000
-      path: snapshot/export.bin
-      downloadURLs:
-      - https://ls.manapotion.io/export.bin
-      - https://x-vps.com/export.bin
-      - https://dbfiles.iota.org/mainnet/hornet/latest-export.bin
-    global:
-      path: snapshot/snapshotMainnet.txt
-      spentAddressesPaths:
-      - previousEpochsSpentAddresses1.txt
-      - previousEpochsSpentAddresses2.txt
-      - previousEpochsSpentAddresses3.txt
-      index: 1050000
-    pruning:
-      enabled: true
-      delay: 10000
-  spentAddresses:
-    enabled: true
-  network:
-    preferIPv6: false
-    gossip:
-      bindAddress: "0.0.0.0:{{ hornet_ports.peering.port }}"
-      reconnectAttemptIntervalSeconds: 60
-    autopeering:
-      bindAddress: "0.0.0.0:{{ hornet_ports.autopeering.port }}"
-      runAsEntryNode: false
-      entryNodes:
-      - "FvfwJuCMoWJvcJLSYww7whPxouZ9WFJ55uyxTxKxJ1ez@enter.hornet.zone:14626"
-      - "EkSLZ4uvSTED1x6KaGzqxoGxjbytt2rPVfbJk1LRLCGL@enter.manapotion.io:18626"
-      - "iotaMk9Rg8wWo1DDeG7fwV9iJ41hvkwFX8w6MyTQgDu@enter.thetangle.org:14627"
-      - "12w9FrzMdDQ42aBgFrv1siHuJMhuZ4SMVHRFSS7Zb72W@entrynode.iotatoken.nl:14626"
-      - "DboTc1v61Xdyvggj8VRszy92ScUTLgfwZaHvXsU8zr7e@entrynode.tanglebay.org:14626"
-      - "31Tz9meznQMm7qSDUgyMmYVeHUCGA7za5Suvbom5hpE9@bender.iota.autopeering.com:14626"
-      seed: ''
-  tipsel:
-    maxDeltaTxYoungestRootSnapshotIndexToLSMI: 2
-    maxDeltaTxApproveesOldestRootSnapshotIndexToLSMI: 7
-    belowMaxDepth: 15
-    nonLazy:
-      retentionRulesTipsLimit: 100
-      maxReferencedTipAgeSeconds: 3
-      maxApprovers: 2
-    semiLazy:
-      retentionRulesTipsLimit: 20
-      maxReferencedTipAgeSeconds: 3
-      maxApprovers: 2
-  node:
-    alias: ''
-    showAliasInGetNodeInfo: false
-    disablePlugins: "{{ hornet_disable_plugins }}"
-    enablePlugins: "{{ hornet_enable_plugins }}"
-  spammer:
-    address: HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999
-    depth: 1
-    message: "Spamming with HORNET tipselect, thank you for using HORNET playbook"
-    tag: HORNET99INTEGRATED99SPAMMER99PLAYBOOK99RULES
-    tagSemiLazy: ''
-    cpuMaxUsage: 0.8
-    tpsRateLimit: 0
-    bundleSize: 1
-    valueSpam: false
-    workers: 0
-    semiLazyTipsLimit: 30
-  zmq:
-    bindAddress: 127.0.0.1:{{ hornet_ports.zmq.port }}
-  profiling:
-    bindAddress: 127.0.0.1:6060
-  prometheus:
-    bindAddress: 127.0.0.1:9312
-    goMetrics: true
-    processMetrics: true
-    promhttpMetrics: true
+
+# useProfile
+hornet_config_useProfile: auto
+
+# httpAPI
+hornet_config_httpAPI_excludeHealthCheckFromAuth: false
+hornet_config_httpAPI_basicAuth_enabled: false
+hornet_config_httpAPI_basicAuth_username: ''
+hornet_config_httpAPI_basicAuth_passwordHash: ''
+hornet_config_httpAPI_basicAuth_passwordSalt: ''
+hornet_config_httpAPI_permitRemoteAccess:
+  - getNodeInfo
+  - getBalances
+  - checkConsistency
+  - getTipInfo
+  - getTransactionsToApprove
+  - getInclusionStates
+  - getNodeAPIConfiguration
+  - wereAddressesSpentFrom
+  - broadcastTransactions
+  - findTransactions
+  - storeTransactions
+  - getTrytes
+  - attachToTangle
+  - interruptAttachingToTangle
+hornet_config_httpAPI_whitelistedAddresses: []
+hornet_config_httpAPI_bindAddress: "127.0.0.1:{{ hornet_ports.api.port }}"
+hornet_config_httpAPI_limits_bodyLengthBytes: 1000000
+hornet_config_httpAPI_limits_findTransactions: 1000
+hornet_config_httpAPI_limits_getTrytes: 1000
+hornet_config_httpAPI_limits_requestsList: 1000
+
+# dashboard
+hornet_config_dashboard_bindAddress: "{{ hornet_graph_internal_address }}:{{ hornet_dashboard_internal_port }}"
+hornet_config_dashboard_theme: default
+hornet_config_dashboard_basicAuth_enabled: false
+hornet_config_dashboard_basicAuth_username: ''
+hornet_config_dashboard_basicAuth_passwordHash: ''
+hornet_config_dashboard_basicAuth_passwordSalt: ''
+
+# snapshots
+hornet_config_snapshots_loadType: local
+hornet_config_snapshots_local_intervalSynced: 50
+hornet_config_snapshots_local_intervalUnsynced: 1000
+hornet_config_snapshots_local_path: snapshot/export.bin
+hornet_config_snapshots_local_downloadURLs:
+  - https://ls.manapotion.io/export.bin
+  - https://x-vps.com/export.bin
+  - https://dbfiles.iota.org/mainnet/hornet/latest-export.bin
+hornet_config_snapshots_global_path: snapshot/snapshotMainnet.txt
+hornet_config_snapshots_global_spentAddressesPaths:
+  - previousEpochsSpentAddresses1.txt
+  - previousEpochsSpentAddresses2.txt
+  - previousEpochsSpentAddresses3.txt
+hornet_config_snapshots_global_index: 1050000
+hornet_config_snapshots_pruning_enabled: true
+hornet_config_snapshots_pruning_delay: 10000
+
+# spentAddresses
+hornet_config_spentAddresses_enabled: true
+
+# coordinator
+hornet_config_coordinator_address: "UDYXTZBE9GZGPM9SSQV9LTZNDLJIZMPUVVXYXFYVBLIEUHLSEWFTKZZLXYRHHWVQV9MNNX9KZC9D9UZWZ"
+hornet_config_coordinator_securityLevel: 2
+hornet_config_coordinator_merkleTreeDepth: 24
+hornet_config_coordinator_mwm: 14
+hornet_config_coordinator_stateFilePath: coordinator/state
+hornet_config_coordinator_merkleTreeFilePath: coordinator/tree
+hornet_config_coordinator_milestoneMerkleTreeHashFunc: BLAKE2b-512
+hornet_config_coordinator_intervalSeconds: 10
+hornet_config_coordinator_checkpoints_maxTrackedTails: 10000
+hornet_config_coordinator_tipsel_minHeaviestBranchUnconfirmedTransactionsThreshold: 20
+hornet_config_coordinator_tipsel_maxHeaviestBranchTipsPerCheckpoint: 10
+hornet_config_coordinator_tipsel_randomTipsPerCheckpoint: 3
+hornet_config_coordinator_tipsel_heaviestBranchSelectionDeadlineMilliseconds: 100
+
+# network
+hornet_config_network_preferIPv6: false
+hornet_config_network_gossip_bindAddress: "0.0.0.0:{{ hornet_ports.peering.port }}"
+hornet_config_network_gossip_reconnectAttemptIntervalSeconds: 60
+hornet_config_network_autopeering_bindAddress: "0.0.0.0:{{ hornet_ports.autopeering.port }}"
+hornet_config_network_autopeering_runAsEntryNode: false
+hornet_config_network_autopeering_entryNodes:
+  - "FvfwJuCMoWJvcJLSYww7whPxouZ9WFJ55uyxTxKxJ1ez@enter.hornet.zone:14626"
+  - "EkSLZ4uvSTED1x6KaGzqxoGxjbytt2rPVfbJk1LRLCGL@enter.manapotion.io:18626"
+  - "iotaMk9Rg8wWo1DDeG7fwV9iJ41hvkwFX8w6MyTQgDu@enter.thetangle.org:14627"
+  - "12w9FrzMdDQ42aBgFrv1siHuJMhuZ4SMVHRFSS7Zb72W@entrynode.iotatoken.nl:14626"
+  - "DboTc1v61Xdyvggj8VRszy92ScUTLgfwZaHvXsU8zr7e@entrynode.tanglebay.org:14626"
+  - "31Tz9meznQMm7qSDUgyMmYVeHUCGA7za5Suvbom5hpE9@bender.iota.autopeering.com:14626"
+hornet_config_network_autopeering_seed: ''
+
+# tipsel
+hornet_config_tipsel_maxDeltaTxYoungestRootSnapshotIndexToLSMI: 8
+hornet_config_tipsel_maxDeltaTxOldestRootSnapshotIndexToLSMI: 13
+hornet_config_tipsel_belowMaxDepth: 15
+hornet_config_tipsel_nonLazy_retentionRulesTipsLimit: 100
+hornet_config_tipsel_nonLazy_maxReferencedTipAgeSeconds: 3
+hornet_config_tipsel_nonLazy_maxApprovers: 2
+hornet_config_tipsel_semiLazy_retentionRulesTipsLimit: 20
+hornet_config_tipsel_semiLazy_maxReferencedTipAgeSeconds: 3
+hornet_config_tipsel_semiLazy_maxApprovers: 2
+
+# node
+hornet_config_node_alias: ''
+hornet_config_node_showAliasInGetNodeInfo: false
+hornet_config_node_disablePlugins: "{{ hornet_disable_plugins }}"
+hornet_config_node_enablePlugins: "{{ hornet_enable_plugins }}"
+
+# spammer
+hornet_config_spammer_address: HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999
+hornet_config_spammer_depth: 1
+hornet_config_spammer_message: "Spamming with HORNET tipselect, thank you for using HORNET playbook"
+hornet_config_spammer_tag: HORNET99INTEGRATED99SPAMMER99PLAYBOOK99RULES
+hornet_config_spammer_tagSemiLazy: ''
+hornet_config_spammer_cpuMaxUsage: 0.8
+hornet_config_spammer_tpsRateLimit: 0
+hornet_config_spammer_bundleSize: 1
+hornet_config_spammer_valueSpam: false
+hornet_config_spammer_workers: 0
+hornet_config_spammer_semiLazyTipsLimit: 30
+
+# zmq
+hornet_config_zmq_bindAddress: "127.0.0.1:{{ hornet_ports.zmq.port }}"
+
+# profiling
+hornet_config_profiling_bindAddress: 127.0.0.1:6060
+
+# prometheus
+hornet_config_prometheus_bindAddress: 127.0.0.1:9312
+hornet_config_prometheus_goMetrics: true
+hornet_config_prometheus_processMetrics: true
+hornet_config_prometheus_promhttpMetrics: true
+hornet_config_prometheus_fileServiceDiscovery_enabled: false
+hornet_config_prometheus_fileServiceDiscovery_path: target.json
+hornet_config_prometheus_fileServiceDiscovery_target: "{{ hornet_config_prometheus_bindAddress }}"
 
 #
 # peers.json

--- a/roles/hornet/templates/hornet_config.json.j2
+++ b/roles/hornet/templates/hornet_config.json.j2
@@ -1,128 +1,135 @@
 {
-{% set c = hornet_configuration.useProfile %}
-  "useProfile": "{{ c }}",
-{% set c = hornet_configuration.httpAPI %}
+  "useProfile": "{{ hornet_config_useProfile }}",
   "httpAPI": {
-    "excludeHealthCheckFromAuth": {{ c.excludeHealthCheckFromAuth | bool | lower | string }},
+    "excludeHealthCheckFromAuth": {{ hornet_config_httpAPI_excludeHealthCheckFromAuth | bool | lower | string }},
     "basicAuth": {
-      "enabled": {{ c.basicAuth.enabled | bool | lower | string }},
-      "username": "{{ c.basicAuth.username }}",
-      "passwordHash": "{{ c.basicAuth.passwordHash }}",
-      "passwordSalt": "{{ c.basicAuth.passwordSalt }}"
+      "enabled": {{ hornet_config_httpAPI_basicAuth_enabled | bool | lower | string }},
+      "username": "{{ hornet_config_httpAPI_basicAuth_username }}",
+      "passwordHash": "{{ hornet_config_httpAPI_basicAuth_passwordHash }}",
+      "passwordSalt": "{{ hornet_config_httpAPI_basicAuth_passwordSalt }}"
     },
-    "permitRemoteAccess": {{ c.permitRemoteAccess | to_nice_json(indent=6) }},
-    "whitelistedAddresses": {{ c.whitelistedAddresses | to_nice_json(indent=6) }},
-    "bindAddress": "{{ c.bindAddress }}",
+    "permitRemoteAccess": {{ hornet_config_httpAPI_permitRemoteAccess | to_nice_json(indent=6) }},
+    "whitelistedAddresses": {{ hornet_config_httpAPI_whitelistedAddresses | to_nice_json(indent=6) }},
+    "bindAddress": "{{ hornet_config_httpAPI_bindAddress }}",
     "limits": {
-      "bodyLengthBytes": {{ c.limits.bodyLengthBytes }},
-      "findTransactions": {{ c.limits.findTransactions }},
-      "getTrytes": {{ c.limits.getTrytes }},
-      "requestsList": {{ c.limits.requestsList }}
+      "bodyLengthBytes": {{ hornet_config_httpAPI_limits_bodyLengthBytes | int }},
+      "findTransactions": {{ hornet_config_httpAPI_limits_findTransactions | int }},
+      "getTrytes": {{ hornet_config_httpAPI_limits_getTrytes | int }},
+      "requestsList": {{ hornet_config_httpAPI_limits_requestsList | int }}
     }
   },
-{% set c = hornet_configuration.dashboard %}
   "dashboard": {
-    "bindAddress": "{{ c.bindAddress }}",
-    "theme": "{{ c.theme }}",
+    "bindAddress": "{{ hornet_config_dashboard_bindAddress }}",
+    "theme": "{{ hornet_config_dashboard_theme }}",
     "basicAuth": {
-      "enabled": {{ c.basicAuth.enabled  | bool | lower | string }},
-      "username": "{{ c.basicAuth.username }}",
-      "passwordHash": "{{ c.basicAuth.passwordHash }}",
-      "passwordSalt": "{{ c.basicAuth.passwordSalt }}"
+      "enabled": {{ hornet_config_dashboard_basicAuth_enabled | bool | lower | string }},
+      "username": "{{ hornet_config_dashboard_basicAuth_username }}",
+      "passwordHash": "{{ hornet_config_dashboard_basicAuth_passwordHash }}",
+      "passwordSalt": "{{ hornet_config_dashboard_basicAuth_passwordSalt }}"
     }
   },
-{% set c = hornet_configuration.snapshots %}
   "snapshots": {
-    "loadType": "{{ c.loadType }}",
+    "loadType": "{{ hornet_config_snapshots_loadType }}",
     "local": {
-      "intervalSynced": {{ c.local.intervalSynced | int }},
-      "intervalUnsynced": {{ c.local.intervalUnsynced | int }},
-      "path": "{{ c.local.path }}",
-      "downloadURLs": {{ c.local.downloadURLs | to_nice_json(indent=8) }}
+      "intervalSynced": {{ hornet_config_snapshots_local_intervalSynced | int }},
+      "intervalUnsynced": {{ hornet_config_snapshots_local_intervalUnsynced | int }},
+      "path": "{{ hornet_config_snapshots_local_path }}",
+      "downloadURLs": {{ hornet_config_snapshots_local_downloadURLs | to_nice_json(indent=8) }}
     },
     "global": {
-      "path": "{{ c.global.path }}",
-      "spentAddressesPaths": {{ c.global.spentAddressesPaths | to_nice_json(indent=8) }},
-      "index": {{ c.global.index | int }}
+      "path": "{{ hornet_config_snapshots_global_path }}",
+      "spentAddressesPaths": {{ hornet_config_snapshots_global_spentAddressesPaths | to_nice_json(indent=8) }},
+      "index": {{ hornet_config_snapshots_global_index | int }}
     },
     "pruning": {
-      "enabled": {{ c.pruning.enabled | bool | lower | string }},
-      "delay": {{ c.pruning.delay | int }}
+      "enabled": {{ hornet_config_snapshots_pruning_enabled | bool | lower | string }},
+      "delay": {{ hornet_config_snapshots_pruning_delay | int }}
     }
   },
-{% set c = hornet_configuration.spentAddresses %}
   "spentAddresses": {
-    "enabled": {{ c.enabled | bool | lower | string }}
+    "enabled": {{  hornet_config_spentAddresses_enabled| bool | lower | string }}
   },
-{%- if 'coordinator' in hornet_configuration %}
-{% set c = hornet_configuration.coordinator %}
   "coordinator": {
-    "address": "{{ c.address }}",
-    "securityLevel": {{ c.securityLevel | int }},
-    "merkleTreeDepth": {{ c.merkleTreeDepth | int }},
-    "mwm": {{ c.mwm | int }},
-    "stateFilePath": "{{ c.stateFilePath }}",
-    "merkleTreeFilePath": "{{ c.merkleTreeFilePath }}",
-    "intervalSeconds": {{ c.intervalSeconds | int }},
+    "address": "{{ hornet_config_coordinator_address }}",
+    "securityLevel": {{ hornet_config_coordinator_securityLevel | int }},
+    "merkleTreeDepth": {{ hornet_config_coordinator_merkleTreeDepth | int }},
+    "mwm": {{ hornet_config_coordinator_mwm | int }},
+    "stateFilePath": "{{ hornet_config_coordinator_stateFilePath }}",
+    "merkleTreeFilePath": "{{ hornet_config_coordinator_merkleTreeFilePath }}",
+    "milestoneMerkleTreeHashFunc": "{{ hornet_config_coordinator_milestoneMerkleTreeHashFunc }}",
+    "intervalSeconds": {{ hornet_config_coordinator_intervalSeconds | int }},
     "checkpoints": {
-      "maxTrackedTails": {{ c.checkpoints.maxTrackedTails | int }}
+      "maxTrackedTails": {{ hornet_config_coordinator_checkpoints_maxTrackedTails | int }}
     },
     "tipsel": {
-      "minHeaviestBranchUnconfirmedTransactionsThreshold": {{ c.tipsel.minHeaviestBranchUnconfirmedTransactionsThreshold | int }},
-      "maxHeaviestBranchTipsPerCheckpoint": {{ c.tipsel.maxHeaviestBranchTipsPerCheckpoint | int }},
-      "randomTipsPerCheckpoint": {{ c.tipsel.randomTipsPerCheckpoint | int }},
-      "heaviestBranchSelectionDeadlineMilliseconds": {{ c.tipsel.heaviestBranchSelectionDeadlineMilliseconds | int }}
+      "minHeaviestBranchUnconfirmedTransactionsThreshold": {{ hornet_config_coordinator_tipsel_minHeaviestBranchUnconfirmedTransactionsThreshold | int }},
+      "maxHeaviestBranchTipsPerCheckpoint": {{ hornet_config_coordinator_tipsel_maxHeaviestBranchTipsPerCheckpoint | int }},
+      "randomTipsPerCheckpoint": {{ hornet_config_coordinator_tipsel_randomTipsPerCheckpoint | int }},
+      "heaviestBranchSelectionDeadlineMilliseconds": {{ hornet_config_coordinator_tipsel_heaviestBranchSelectionDeadlineMilliseconds | int }}
     }
   },
-{%- endif %}
-{% set c = hornet_configuration.network %}
   "network": {
-    "preferIPv6": {{ c.preferIPv6 | bool | lower | string }},
+    "preferIPv6": {{ hornet_config_network_preferIPv6 | bool | lower | string }},
     "gossip": {
-      "bindAddress": "{{ c.gossip.bindAddress }}",
-      "reconnectAttemptIntervalSeconds": {{ c.gossip.reconnectAttemptIntervalSeconds | int }}
+      "bindAddress": "{{ hornet_config_network_gossip_bindAddress }}",
+      "reconnectAttemptIntervalSeconds": {{ hornet_config_network_gossip_reconnectAttemptIntervalSeconds | int }}
     },
     "autopeering": {
-      "bindAddress": "{{ c.autopeering.bindAddress }}",
-      "runAsEntryNode": {{ c.autopeering.runAsEntryNode | bool | lower | string }},
-      "entryNodes": {{ c.autopeering.entryNodes | to_nice_json(indent=8) }},
-      "seed": "{{ c.autopeering.seed }}"
+      "bindAddress": "{{ hornet_config_network_autopeering_bindAddress }}",
+      "runAsEntryNode": {{ hornet_config_network_autopeering_runAsEntryNode | bool | lower | string }},
+      "entryNodes": {{ hornet_config_network_autopeering_entryNodes | to_nice_json(indent=8) }},
+      "seed": "{{ hornet_config_network_autopeering_seed }}"
     }
   },
-{% set c = hornet_configuration.node %}
+  "tipsel": {
+    "belowMaxDepth": {{ hornet_config_tipsel_belowMaxDepth | int }},
+    "maxDeltaTxOldestRootSnapshotIndexToLSMI": {{ hornet_config_tipsel_maxDeltaTxOldestRootSnapshotIndexToLSMI | int }},
+    "maxDeltaTxYoungestRootSnapshotIndexToLSMI": {{ hornet_config_tipsel_maxDeltaTxYoungestRootSnapshotIndexToLSMI | int }},
+    "nonLazy": {
+      "maxApprovers": {{ hornet_config_tipsel_nonLazy_maxApprovers | int }},
+      "maxReferencedTipAgeSeconds": {{ hornet_config_tipsel_nonLazy_maxReferencedTipAgeSeconds | int }},
+      "retentionRulesTipsLimit": {{ hornet_config_tipsel_semiLazy_retentionRulesTipsLimit | int }}
+    },
+    "semiLazy": {
+      "maxApprovers": {{ hornet_config_tipsel_semiLazy_maxApprovers | int }},
+      "maxReferencedTipAgeSeconds": {{ hornet_config_tipsel_semiLazy_maxReferencedTipAgeSeconds | int }},
+      "retentionRulesTipsLimit": {{ hornet_config_tipsel_semiLazy_retentionRulesTipsLimit | int }}
+    }
+  },
   "node": {
-    "alias": "{{ c.alias }}",
-    "showAliasInGetNodeInfo": {{ c.showAliasInGetNodeInfo | bool | lower | string }},
-    "disablePlugins": {{ c.disablePlugins | to_nice_json(indent=6) }},
-    "enablePlugins": {{ c.enablePlugins | to_nice_json(indent=6) }}
+    "alias": "{{ hornet_config_node_alias }}",
+    "showAliasInGetNodeInfo": {{ hornet_config_node_showAliasInGetNodeInfo | bool | lower | string }},
+    "disablePlugins": {{ hornet_config_node_disablePlugins | to_nice_json(indent=6) }},
+    "enablePlugins": {{ hornet_config_node_enablePlugins | to_nice_json(indent=6) }}
   },
-{% set c = hornet_configuration.spammer %}
   "spammer": {
-    "address": "{{ c.address }}",
-    "depth": {{ c.depth | int }},
-    "message": "{{ c.message }}",
-    "tag": "{{ c.tag }}",
-    "tagSemiLazy": "{{ c.tagSemiLazy }}",
-    "cpuMaxUsage": {{ c.cpuMaxUsage | float }},
-    "tpsRateLimit": {{ c.tpsRateLimit | int }},
-    "bundleSize": {{ c.bundleSize }},
-    "valueSpam": {{ c.valueSpam | bool | lower | string }},
-    "workers": {{ c.workers | int }},
-    "semiLazyTipsLimit": {{ c.semiLazyTipsLimit | int }}
+    "address": "{{ hornet_config_spammer_address }}",
+    "depth": {{ hornet_config_spammer_depth | int }},
+    "message": "{{ hornet_config_spammer_message }}",
+    "tag": "{{ hornet_config_spammer_tag }}",
+    "tagSemiLazy": "{{ hornet_config_spammer_tagSemiLazy }}",
+    "cpuMaxUsage": {{ hornet_config_spammer_cpuMaxUsage | float }},
+    "tpsRateLimit": {{ hornet_config_spammer_tpsRateLimit | int }},
+    "bundleSize": {{ hornet_config_spammer_bundleSize }},
+    "valueSpam": {{ hornet_config_spammer_valueSpam | bool | lower | string }},
+    "workers": {{ hornet_config_spammer_workers | int }},
+    "semiLazyTipsLimit": {{ hornet_config_spammer_semiLazyTipsLimit | int }}
   },
-{% set c = hornet_configuration.zmq %}
   "zmq": {
-    "bindAddress": "{{ c.bindAddress }}"
+    "bindAddress": "{{ hornet_config_zmq_bindAddress }}"
   },
-{% set c = hornet_configuration.profiling %}
   "profiling": {
-    "bindAddress": "{{ c.bindAddress }}"
+    "bindAddress": "{{ hornet_config_profiling_bindAddress }}"
   },
-{% set c = hornet_configuration.prometheus %}
   "prometheus": {
-    "bindAddress": "{{ c.bindAddress }}",
-    "goMetrics": {{ c.goMetrics | bool | lower | string }},
-    "processMetrics": {{ c.processMetrics | bool | lower | string }},
-    "promhttpMetrics": {{ c.promhttpMetrics | bool | lower | string }}
+    "bindAddress": "{{ hornet_config_prometheus_bindAddress }}",
+    "goMetrics": {{ hornet_config_prometheus_goMetrics | bool | lower | string }},
+    "processMetrics": {{ hornet_config_prometheus_processMetrics | bool | lower | string }},
+    "promhttpMetrics": {{ hornet_config_prometheus_promhttpMetrics | bool | lower | string }},
+    "fileServiceDiscovery": {
+      "enabled": {{ hornet_config_prometheus_fileServiceDiscovery_enabled | bool | lower | string }},
+      "path": "{{ hornet_config_prometheus_fileServiceDiscovery_path }}",
+      "target": "{{ hornet_config_prometheus_fileServiceDiscovery_target }}"
+    }
   }
 }

--- a/roles/shared-files/comnet-vars.yml
+++ b/roles/shared-files/comnet-vars.yml
@@ -1,161 +1,26 @@
-# Configuration for comnet
+# Configuration for comnet (main config override values)
 #
 # config.json
-hornet_configuration:
-  useProfile: auto
-  httpAPI:
-    excludeHealthCheckFromAuth: false
-    basicAuth:
-      enabled: false
-      username: ''
-      passwordHash: ''
-      passwordSalt: ''
-    permitRemoteAccess:
-    - getNodeInfo
-    - getBalances
-    - checkConsistency
-    - getTipInfo
-    - getTransactionsToApprove
-    - getInclusionStates
-    - getNodeAPIConfiguration
-    - wereAddressesSpentFrom
-    - broadcastTransactions
-    - findTransactions
-    - storeTransactions
-    - getTrytes
-    - attachToTangle
-    - interruptAttachingToTangle
-    whitelistedAddresses: []
-    bindAddress: "127.0.0.1:{{ hornet_ports.api.port }}"
-    limits:
-      bodyLengthBytes: 1000000
-      findTransactions: 100000
-      getTrytes: 1000
-      requestsList: 1000
-  dashboard:
-    bindAddress: "{{ hornet_graph_internal_address }}:{{ hornet_dashboard_internal_port }}"
-    theme: default
-    basicAuth:
-      enabled: false
-      username: ''
-      passwordHash: ''
-      passwordSalt: ''
-  snapshots:
-    loadType: local
-    local:
-      intervalSynced: 200
-      intervalUnsynced: 1000
-      path: snapshot/export.bin
-      downloadURLs:
-      - https://ls.manapotion.io/comnet/export.bin
-    global:
-      path: snapshot/snapshotMainnet.txt
-      spentAddressesPaths:
-      - previousEpochsSpentAddresses1.txt
-      - previousEpochsSpentAddresses2.txt
-      - previousEpochsSpentAddresses3.txt
-      index: 1050000
-    pruning:
-      enabled: true
-      delay: 1000
-  spentAddresses:
-    enabled: true
-  network:
-    preferIPv6: false
-    gossip:
-      bindAddress: "0.0.0.0:{{ hornet_ports.peering.port }}"
-      reconnectAttemptIntervalSeconds: 60
-    autopeering:
-      bindAddress: "0.0.0.0:{{ hornet_ports.autopeering.port }}"
-      runAsEntryNode: false
-      entryNodes:
-      - "iotaCrvEWGfaeA1HutcULjD4uZnPhEnD5xNGfGs8vhe@enter.comnet.thetangle.org:14647"
-      - "GLZAWBGqvm6ZRT7jGMFAKyUJNPdvx4i5A1GPRZbGS6C9@enter.comnet.hornet.zone:14627"
-      - "J1Hn5r9pS5FkLeYqXWstC2Zyjxj73grEWvjuene3qjM9@entrynode.comnet.tanglebay.org:14636"
-      seed: ''
-  coordinator:
-    address: "UOMFQOULWQLXQQHFMFRQQTRDKDHVMRFFEGZ9LDU9TFZZ9CHDLZSIAHA9MXNSLYOERCHDUVDFEEZAEOBEW"
-    securityLevel: 2
-    merkleTreeDepth: 23
-    mwm: 10
-    stateFilePath: coordinator/state
-    merkleTreeFilePath: coordinator/tree
-    intervalSeconds: 60
-    checkpoints:
-      maxTrackedTails: 10000
-    tipsel:
-      minHeaviestBranchUnconfirmedTransactionsThreshold: 20
-      maxHeaviestBranchTipsPerCheckpoint: 10
-      randomTipsPerCheckpoint: 2
-      heaviestBranchSelectionDeadlineMilliseconds: 100
-  tipsel:
-    maxDeltaTxYoungestRootSnapshotIndexToLSMI: 2
-    maxDeltaTxApproveesOldestRootSnapshotIndexToLSMI: 7
-    belowMaxDepth: 15
-    nonLazy:
-      retentionRulesTipsLimit: 100
-      maxReferencedTipAgeSeconds: 3
-      maxApprovers: 2
-    semiLazy:
-      retentionRulesTipsLimit: 20
-      maxReferencedTipAgeSeconds: 3
-      maxApprovers: 2
-  node:
-    alias: ''
-    showAliasInGetNodeInfo: false
-    disablePlugins: "{{ hornet_disable_plugins }}"
-    enablePlugins: "{{ hornet_enable_plugins }}"
-  spammer:
-    address: HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999
-    depth: 1
-    message: "Spamming with HORNET tipselect, thank you for using HORNET playbook"
-    tag: HORNET99INTEGRATED99SPAMMER99PLAYBOOK99RULES
-    tagSemiLazy: ''
-    cpuMaxUsage: 0.8
-    tpsRateLimit: 0
-    bundleSize: 1
-    valueSpam: false
-    workers: 0
-    semiLazyTipsLimit: 30
-  zmq:
-    bindAddress: 127.0.0.1:{{ hornet_ports.zmq.port }}
-  profiling:
-    bindAddress: 127.0.0.1:6060
-  prometheus:
-    bindAddress: 127.0.0.1:9312
-    goMetrics: true
-    processMetrics: true
-    promhttpMetrics: true
 
-#
-# peers.json
-# Example:
-#  - identity: example1.neighbor.com:15600
-#    preferIPv6: false
-#    alias: first_node
-#  - identity: example2.neighbor.com:15600
-#    alias: second_node
-#    preferIPv6: false
-hornet_peers: []
-hornet_accept_any_connection: "false"
-hornet_max_peers: 5
+# snapshots
+hornet_config_snapshots_local_intervalSynced: 50
+hornet_config_snapshots_local_downloadURLs:
+  - https://ls.manapotion.io/comnet/export.bin
+hornet_config_snapshots_pruning_delay: 1000
 
-#
-# mqtt_config.json
-mqtt_worker_number: 4096
-mqtt_internal_port: "11883"
-mqtt_internal_address: 127.0.0.1
-mqtt_proxy_port: "{{ hornet_ports.mqtt.port }}"
-mqtt_ws_path: /ws
-mqtt_tls_enabled: "false"
-mqtt_ca_file: tls/ca/cacert.pem
-mqtt_cert_file: tls/server/cert.pem
-mqtt_key_file: tls/server/key.pem
+# network
+hornet_config_network_autopeering_entryNodes:
+  - "iotaCrvEWGfaeA1HutcULjD4uZnPhEnD5xNGfGs8vhe@enter.comnet.thetangle.org:14647"
+  - "GLZAWBGqvm6ZRT7jGMFAKyUJNPdvx4i5A1GPRZbGS6C9@enter.comnet.hornet.zone:14627"
+  - "J1Hn5r9pS5FkLeYqXWstC2Zyjxj73grEWvjuene3qjM9@entrynode.comnet.tanglebay.org:14636"
 
-#
-# Aliases used in generic roles (e.g. ansible-monitoring)
-node_db_path: "{{ hornet_config.db.path }}"
-node_zmq_port: "{{ hornet_ports.zmq.port }}"
-node_enable_plugins: "{{ hornet_config.node.enablePlugins }}"
-node_api_port: "{{ hornet_ports.api.port }}"
-node_api_port_remote: "14267"
+# coordinator
+hornet_config_coordinator_address: "UOMFQOULWQLXQQHFMFRQQTRDKDHVMRFFEGZ9LDU9TFZZ9CHDLZSIAHA9MXNSLYOERCHDUVDFEEZAEOBEW"
+hornet_config_coordinator_merkleTreeDepth: 23
+hornet_config_coordinator_mwm: 10
+hornet_config_coordinator_intervalSeconds: 60
+hornet_config_coordinator_tipsel_randomTipsPerCheckpoint: 2
+
+# tipsel
+hornet_config_tipsel_maxDeltaTxYoungestRootSnapshotIndexToLSMI: 2
+hornet_config_tipsel_maxDeltaTxOldestRootSnapshotIndexToLSMI: 7


### PR DESCRIPTION
Move away from using full yaml config structure to something more flat.
This allows to easily override specific values in variable-override files rather than having to copy the entire source config and only changing the required values.