### PR TITLE
Fix file name in instructions to rerun update

### DIFF
--- a/roles/hornet/files/horc
+++ b/roles/hornet/files/horc
@@ -569,7 +569,7 @@ function run_custom_updates(){
                 touch "${_UPDATE}.completed"
             fi
         else
-            echo "$(basename ${_UPDATE}) already updated. To force rerun this update remove the file '${_UPDATE}' and rerun horc."
+            echo "$(basename ${_UPDATE}) already updated. To force rerun this update remove the file '${_UPDATE}.completed' and rerun horc."
         fi
     done
 


### PR DESCRIPTION
The message tells the user to delete the update script (e.g. `1.0.1_updates.sh`), when it should tell users to delete the `completed` file (e.g. `1.0.1_updates.sh.completed`)