### PR TITLE
Remove Set node Peer ID references

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,16 +173,6 @@ Make sure you are root (`sudo su`) and run:
 horc
 ```
 
-## Node Peer ID
-
-During installation the installer script generates a static unique peer ID using Hornet. The key is stored in `/opt/hornet-playbook/group_vars/all/z-installer-override.yml`.
-
-The private key is configured in `/var/lib/hornet/config.json`, thus the ID is kept even if the p2p DB get corrupted or deleted.
-
-You may also choose to back up the key in a safe place in case you need to recover your node's ID due to a failure.
-
-There's an option in `horc` to regenerate the Peer ID if needed.
-
 ## Hornet Dashboard
 
 Point your browser to your host's IP address or fully qualified domain name, e.g.:

--- a/roles/hornet/files/horc
+++ b/roles/hornet/files/horc
@@ -1362,63 +1362,6 @@ function toggle_comnet(){
     pause "$MSG Press ENTER to return to menu."
 }
 
-function set_node_peer_id(){
-    local OUTPUT
-    local TAG
-    local PRIVATE_KEY
-    local PEER_ID
-
-    if grep -q ^hornet_config_p2p_identityPrivateKey /opt/hornet-playbook/group_vars/all/z-installer-override.yml
-    then
-        if ! (whiptail --title "Existing private key" \
-                 --yesno "Node already has a private key set in /opt/hornet-playbook/group_vars/all/z-installer-override.yml\n\nWould you like to re-generate the ID? (Note that you'll have to let your existing peers know about the ID change)." \
-                 --defaultno \
-                 12 $WIDTH)
-        then
-            return 0
-        fi
-    fi
-
-    if [ -f "/etc/default/hornet" ]
-    then
-        TAG=$(grep ^TAG /etc/default/hornet | cut -d'=' -f 2)
-    elif [ -f "/etc/sysconfig/hornet" ]
-    then
-        TAG=$(grep ^TAG /etc/sysconfig/hornet | cut -d'=' -f 2)
-    fi
-
-    echo "Get new ID ..."
-    OUTPUT=$(/usr/bin/docker run -it --rm --name getp2pID "gohornet/hornet:${TAG}" tools p2pidentity-gen)
-
-    # TODO: open github issue for hornet team to output in json format as an option
-    PRIVATE_KEY=$(echo "$OUTPUT" | sed 's|^.*Your p2p private key: \([a-f0-9]*\)|\1|' | head -1 | tr -d ' ' | tr -d '\r')
-    PEER_ID=$(echo "$OUTPUT" | tail -1 | awk -F":" {'print $2'} | tr -d ' ' | tr -d '\r')
-
-    # Make sure old values are gone
-    sed -i '/^hornet_config_p2p_identityPrivateKey/d' /opt/hornet-playbook/group_vars/all/z-installer-override.yml
-    sed -i '/^hornet_config_p2p_identityPeerID/d' /opt/hornet-playbook/group_vars/all/z-installer-override.yml
-
-    echo "hornet_config_p2p_identityPrivateKey: $PRIVATE_KEY" >> /opt/hornet-playbook/group_vars/all/z-installer-override.yml
-    echo "hornet_config_p2p_identityPeerID: $PEER_ID" >> /opt/hornet-playbook/group_vars/all/z-installer-override.yml
-
-    tmpfile=$(mktemp /tmp/hornet.config.XXXXXX)
-    cp -- "/var/lib/hornet/config.json" "/var/lib/hornet/config.json.$(date +%s)"
-    jq '.p2p.identityPrivateKey="'$PRIVATE_KEY'"' < /var/lib/hornet/config.json > "$tmpfile"
-    mv -- "$tmpfile" "/var/lib/hornet/config.json"
-    chown hornet:hornet "/var/lib/hornet/config.json"
-    chmod 600 "/var/lib/hornet/config.json"
-
-    echo "Stopping hornet to remove old identity ..."
-    /bin/systemctl stop hornet
-
-    rm -rf /var/lib/hornet/p2p/*
-
-    echo "Starting hornet with new identity ..."
-    /bin/systemctl start hornet
-
-    pause "Done setting new peer ID. Press ENTER to return to menu."
-}
-
 ### Peers ###
 function peers_menu(){
     whiptail --title "HORC v${__VERSION__} - Peers" \
@@ -1491,7 +1434,6 @@ function main_menu() {
     "m)" "Set DB Maximum Size" \
     "n)" "Peers" \
     "o)" "Update config.json" \
-    "p)" "Set node Peer ID" \
     "Z)" "Configure this Script" \
     3>&1 1>&2 2>&3
 }
@@ -1582,11 +1524,6 @@ function run_main_menu() {
 
         "o)")
             update_config
-            run_main_menu
-            ;;
-
-        "p)")
-            set_node_peer_id
             run_main_menu
             ;;
 

--- a/roles/hornet/files/horc
+++ b/roles/hornet/files/horc
@@ -1388,7 +1388,7 @@ function set_node_peer_id(){
     fi
 
     echo "Get new ID ..."
-    OUTPUT=$(/usr/bin/docker run -it --rm --name getp2pID "gohornet/hornet:${TAG}" tools p2pidentity)
+    OUTPUT=$(/usr/bin/docker run -it --rm --name getp2pID "gohornet/hornet:${TAG}" tools p2pidentity-gen)
 
     # TODO: open github issue for hornet team to output in json format as an option
     PRIVATE_KEY=$(echo "$OUTPUT" | sed 's|^.*Your p2p private key: \([a-f0-9]*\)|\1|' | head -1 | tr -d ' ' | tr -d '\r')


### PR DESCRIPTION
`identityPrivateKey` was [removed ](https://github.com/gohornet/hornet/releases/tag/v1.0.5) in hornet 1.0.5. 

Closes #51

/cc @nuriel77 